### PR TITLE
fixed version issue about diffusers+Flux

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - pip:
     - datasets==2.18
     - transformers==4.38.2
-    - diffusers==0.28
+    - diffusers==0.30.0
     - hpsv2==1.2
     - image-reward==1.5
     - open-clip-torch==2.24


### PR DESCRIPTION
Hello, thanks for your valuable work. 
After you support flux with diffusers, version of diffusers should be >= 0.30.0 since Flux was supported from this version. 
For me, there was no issue after I updated diffusers==0.30.0.

Thanks. 